### PR TITLE
Use the correct Rust version in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
 rust:
-  - nightly
+  - nightly-2018-06-28
   


### PR DESCRIPTION
Currently the CI installs the latest nightly, but right after that it downloads the version in `rust-toolchain`. This will speed up the CI.